### PR TITLE
Feat msg analyzer

### DIFF
--- a/ouster-ros/CMakeLists.txt
+++ b/ouster-ros/CMakeLists.txt
@@ -130,7 +130,7 @@ endfunction()
 
 # ==== os_sensor_component ====
 create_ros2_component(os_sensor_component
-  "src/os_sensor_node_base.cpp;src/os_sensor_node.cpp;src/sensor_diagnostics_tracker.cpp"
+  "src/os_sensor_node_base.cpp;src/os_sensor_node.cpp;src/sensor_diagnostics_tracker.cpp;src/msg_analyzers.cpp"
   "std_srvs"
 )
 rclcpp_components_register_node(os_sensor_component
@@ -170,7 +170,7 @@ rclcpp_components_register_node(os_image_component
 
 # ==== os_driver_component ====
 create_ros2_component(os_driver_component
-  "src/os_sensor_node_base.cpp;src/os_sensor_node.cpp;src/os_driver_node.cpp;src/sensor_diagnostics_tracker.cpp"
+  "src/os_sensor_node_base.cpp;src/os_sensor_node.cpp;src/os_driver_node.cpp;src/sensor_diagnostics_tracker.cpp;src/msg_analyzers.cpp"
   "std_srvs"
 )
 rclcpp_components_register_node(os_driver_component
@@ -197,11 +197,13 @@ if(BUILD_TESTING)
   ament_add_gtest(${PROJECT_NAME}_test
     src/os_ros.cpp
     src/sensor_diagnostics_tracker.cpp
+    src/msg_analyzers.cpp
     test/test_main.cpp
     test/lock_free_ring_buffer_test.cpp
     test/point_accessor_test.cpp
     test/point_transform_test.cpp
     test/point_cloud_compose_test.cpp
+    test/test_msg_analyzers.cpp
     test/test_sensor_diagnostics_tracker.cpp
   )
   ament_target_dependencies(${PROJECT_NAME}_test

--- a/ouster-ros/include/ouster_ros/diagnostics_visitor_registry.h
+++ b/ouster-ros/include/ouster_ros/diagnostics_visitor_registry.h
@@ -1,0 +1,194 @@
+/**
+ * Copyright (c) 2018-2023, Ouster, Inc.
+ * All rights reserved.
+ *
+ * @file diagnostics_visitor_registry.h
+ * @brief Standalone visitor registry with observability API (no ouster SDK
+ * dependencies)
+ */
+
+#pragma once
+
+#include <diagnostic_msgs/msg/key_value.hpp>
+#include <functional>
+#include <optional>
+#include <tuple>
+#include <type_traits>
+#include <vector>
+
+namespace ouster_ros {
+
+template <typename... MsgT>
+struct DiagnosticsVisitorRegistry {
+   public:
+    // Public type definitions
+    template <typename MessageType, typename VisitorFunc>
+    struct visitor_registration {
+        VisitorFunc visitor;
+        explicit visitor_registration(VisitorFunc&& v)
+            : visitor(std::forward<VisitorFunc>(v)) {}
+    };
+
+    template <typename MessageType>
+    using VisitorFunction =
+        std::function<std::vector<diagnostic_msgs::msg::KeyValue>(
+            const MessageType&)>;
+
+    // Public static helper functions
+    template <typename MessageType, typename VisitorFunc>
+    static auto make_visitor(VisitorFunc&& visitor) {
+        return visitor_registration<MessageType, VisitorFunc>(
+            std::forward<VisitorFunc>(visitor));
+    }
+
+    DiagnosticsVisitorRegistry() = default;
+
+    template <typename... VisitorRegs>
+    explicit DiagnosticsVisitorRegistry(VisitorRegs&&... visitor_regs) {
+        (register_any_visitor(std::forward<VisitorRegs>(visitor_regs)), ...);
+    }
+
+    template <typename MessageType>
+    std::vector<diagnostic_msgs::msg::KeyValue> operator()(
+        const MessageType& msg) const {
+        static_assert((std::is_same_v<MessageType, MsgT> || ...),
+                      "MessageType must be one of the "
+                      "DiagnosticsVisitorRegistry template parameters");
+
+        const auto& visitor_opt = get_visitor<MessageType>();
+
+        if (visitor_opt.has_value()) {
+            return visitor_opt.value()(msg);
+        } else {
+            return default_analysis<MessageType>();
+        }
+    }
+
+    template <typename VisitorFunc>
+    void register_visitor(VisitorFunc&& visitor) {
+        using MessageType =
+            typename function_traits<std::decay_t<VisitorFunc>>::message_type;
+        register_visitor_impl<MessageType>(std::forward<VisitorFunc>(visitor));
+    }
+
+    template <typename T>
+    static constexpr bool supports() {
+        return (std::is_same_v<T, MsgT> || ...);
+    }
+
+    template <typename T>
+    bool has_visitor() const noexcept {
+        static_assert(supports<T>(),
+                      "Type not registered");
+        return get_visitor<T>().has_value();
+    }
+
+    template <typename Callable>
+    void for_each_supported(Callable&& c) const {
+        (static_cast<void>(
+             std::forward<Callable>(c).template operator()<MsgT>()),
+         ...);
+    }
+
+    template <typename Callable>
+    void for_each_registered(Callable&& c) const {
+        (void)std::initializer_list<int>{
+            (get_visitor<MsgT>().has_value()
+                 ? (std::forward<Callable>(c).template operator()<MsgT>(), 0)
+                 : 0)...};
+    }
+
+   private:
+
+    std::tuple<std::optional<VisitorFunction<MsgT>>...> visitors_;
+
+    // Private helper types for lambda type deduction
+    template <typename T>
+    struct function_traits;
+
+    template <typename R, typename Arg>
+    struct function_traits<R (*)(Arg)> {
+        using message_type = std::decay_t<Arg>;
+    };
+
+    template <typename R, typename C, typename Arg>
+    struct function_traits<R (C::*)(Arg) const> {
+        using message_type = std::decay_t<Arg>;
+    };
+
+    template <typename Lambda>
+    struct function_traits : function_traits<decltype(&Lambda::operator())> {};
+
+    template <typename MessageType, typename VisitorFunc>
+    void register_visitor_impl(VisitorFunc&& visitor) {
+        static_assert((std::is_same_v<MessageType, MsgT> || ...),
+                      "MessageType must be one of the "
+                      "DiagnosticsVisitorRegistry template parameters");
+
+        using ReturnType =
+            std::invoke_result_t<VisitorFunc, const MessageType&>;
+        using ExpectedReturnType = std::vector<diagnostic_msgs::msg::KeyValue>;
+        static_assert(
+            std::is_convertible_v<ReturnType, ExpectedReturnType>,
+            "Visitor must return std::vector<diagnostic_msgs::msg::KeyValue>");
+
+        VisitorFunction<MessageType> typed_visitor =
+            std::forward<VisitorFunc>(visitor);
+        std::get<std::optional<VisitorFunction<MessageType>>>(visitors_) =
+            std::move(typed_visitor);
+    }
+
+
+    template <typename MessageType>
+    const std::optional<VisitorFunction<MessageType>>& get_visitor() const {
+        static_assert((std::is_same_v<MessageType, MsgT> || ...),
+                      "MessageType must be one of the "
+                      "DiagnosticsVisitorRegistry template parameters");
+
+        return std::get<std::optional<VisitorFunction<MessageType>>>(visitors_);
+    }
+
+    template <typename MessageType, typename VisitorFunc>
+    void register_from_helper(
+        visitor_registration<MessageType, VisitorFunc>&& reg) {
+        register_visitor_impl<MessageType>(std::move(reg.visitor));
+    }
+
+    template <typename VisitorFunc>
+    void register_from_lambda(VisitorFunc&& visitor_func) {
+        using MessageType =
+            typename function_traits<std::decay_t<VisitorFunc>>::message_type;
+        static_assert((std::is_same_v<MessageType, MsgT> || ...),
+                      "Lambda message type must be one of the "
+                      "DiagnosticsVisitorRegistry template parameters");
+
+        register_visitor_impl<MessageType>(std::forward<VisitorFunc>(visitor_func));
+    }
+
+    template <typename MessageType>
+    const std::vector<diagnostic_msgs::msg::KeyValue>& default_analysis()
+        const noexcept {
+        const static std::vector<diagnostic_msgs::msg::KeyValue> empty;
+        return empty;
+    }
+
+    template <typename MessageType, typename VisitorFunc>
+    void register_any_visitor(
+        visitor_registration<MessageType, VisitorFunc>&& reg) {
+        register_from_helper(std::move(reg));
+    }
+
+    template <typename VisitorFunc>
+    void register_any_visitor(VisitorFunc&& visitor_func) {
+        register_visitor(std::forward<VisitorFunc>(visitor_func));
+    }
+};
+
+template <typename... MsgT, typename... VisitorRegs>
+DiagnosticsVisitorRegistry<MsgT...> make_visitor_registry(
+    VisitorRegs&&... visitor_regs) {
+    return DiagnosticsVisitorRegistry<MsgT...>(
+        std::forward<VisitorRegs>(visitor_regs)...);
+}
+
+}  // namespace ouster_ros

--- a/ouster-ros/include/ouster_ros/diagnostics_visitor_registry.h
+++ b/ouster-ros/include/ouster_ros/diagnostics_visitor_registry.h
@@ -16,179 +16,198 @@
 #include <type_traits>
 #include <vector>
 
-namespace ouster_ros {
+namespace ouster_ros
+{
 
 template <typename... MsgT>
-struct DiagnosticsVisitorRegistry {
-   public:
-    // Public type definitions
-    template <typename MessageType, typename VisitorFunc>
-    struct visitor_registration {
-        VisitorFunc visitor;
-        explicit visitor_registration(VisitorFunc&& v)
-            : visitor(std::forward<VisitorFunc>(v)) {}
-    };
+struct DiagnosticsVisitorRegistry
+{
+public:
+  // Public type definitions
+  template <typename MessageType, typename VisitorFunc>
+  struct visitor_registration
+  {
+    VisitorFunc visitor;
+    explicit visitor_registration(VisitorFunc && v) : visitor(std::forward<VisitorFunc>(v)) {}
+  };
 
-    template <typename MessageType>
-    using VisitorFunction =
-        std::function<std::vector<diagnostic_msgs::msg::KeyValue>(
-            const MessageType&)>;
+  template <typename MessageType>
+  using VisitorFunction =
+    std::function<std::vector<diagnostic_msgs::msg::KeyValue>(const MessageType &)>;
 
-    // Public static helper functions
-    template <typename MessageType, typename VisitorFunc>
-    static auto make_visitor(VisitorFunc&& visitor) {
-        return visitor_registration<MessageType, VisitorFunc>(
-            std::forward<VisitorFunc>(visitor));
+  // Public static helper functions
+  template <typename MessageType, typename VisitorFunc>
+  static auto make_visitor(VisitorFunc && visitor)
+  {
+    return visitor_registration<MessageType, VisitorFunc>(std::forward<VisitorFunc>(visitor));
+  }
+
+  DiagnosticsVisitorRegistry() = default;
+
+  template <typename... VisitorRegs>
+  explicit DiagnosticsVisitorRegistry(VisitorRegs &&... visitor_regs)
+  {
+    (register_any_visitor(std::forward<VisitorRegs>(visitor_regs)), ...);
+  }
+
+  template <typename MessageType>
+  std::vector<diagnostic_msgs::msg::KeyValue> operator()(const MessageType & msg) const
+  {
+    static_assert(
+      (std::is_same_v<MessageType, MsgT> || ...),
+      "MessageType must be one of the "
+      "DiagnosticsVisitorRegistry template parameters");
+
+    const auto & visitor_opt = get_visitor<MessageType>();
+
+    if (visitor_opt.has_value()) {
+      return visitor_opt.value()(msg);
+    } else {
+      return default_analysis<MessageType>();
     }
+  }
 
-    DiagnosticsVisitorRegistry() = default;
+  template <typename VisitorFunc>
+  void register_visitor(VisitorFunc && visitor)
+  {
+    using MessageType = typename function_traits<std::decay_t<VisitorFunc>>::message_type;
+    register_visitor_impl<MessageType>(std::forward<VisitorFunc>(visitor));
+  }
 
-    template <typename... VisitorRegs>
-    explicit DiagnosticsVisitorRegistry(VisitorRegs&&... visitor_regs) {
-        (register_any_visitor(std::forward<VisitorRegs>(visitor_regs)), ...);
-    }
+  template <typename T>
+  static constexpr bool supports()
+  {
+    return (std::is_same_v<T, MsgT> || ...);
+  }
 
-    template <typename MessageType>
-    std::vector<diagnostic_msgs::msg::KeyValue> operator()(
-        const MessageType& msg) const {
-        static_assert((std::is_same_v<MessageType, MsgT> || ...),
-                      "MessageType must be one of the "
-                      "DiagnosticsVisitorRegistry template parameters");
+  template <typename T>
+  bool has_visitor() const noexcept
+  {
+    static_assert(supports<T>(), "Type not registered");
+    return get_visitor<T>().has_value();
+  }
 
-        const auto& visitor_opt = get_visitor<MessageType>();
+  template <typename Callable>
+  void for_each_supported(Callable && c) const
+  {
+    (static_cast<void>(std::forward<Callable>(c).template operator()<MsgT>()), ...);
+  }
 
-        if (visitor_opt.has_value()) {
-            return visitor_opt.value()(msg);
-        } else {
-            return default_analysis<MessageType>();
-        }
-    }
+  template <typename Callable>
+  void for_each_registered(Callable && c) const
+  {
+    (void)std::initializer_list<int>{
+      (get_visitor<MsgT>().has_value() ? (std::forward<Callable>(c).template operator()<MsgT>(), 0)
+                                       : 0)...};
+  }
 
-    template <typename VisitorFunc>
-    void register_visitor(VisitorFunc&& visitor) {
-        using MessageType =
-            typename function_traits<std::decay_t<VisitorFunc>>::message_type;
-        register_visitor_impl<MessageType>(std::forward<VisitorFunc>(visitor));
-    }
+private:
+  std::tuple<std::optional<VisitorFunction<MsgT>>...> visitors_;
 
-    template <typename T>
-    static constexpr bool supports() {
-        return (std::is_same_v<T, MsgT> || ...);
-    }
+  // Private helper types for callable type deduction
+  template <typename T>
+  struct function_traits;
+  // Function pointer
+  template <typename R, typename Arg>
+  struct function_traits<R (*)(Arg)>
+  {
+    using message_type = std::decay_t<Arg>;
+  };
+  // Member function pointer (const)
+  template <typename R, typename C, typename Arg>
+  struct function_traits<R (C::*)(Arg) const>
+  {
+    using message_type = std::decay_t<Arg>;
+  };
+  // Member function pointer (non-const)
+  template <typename R, typename C, typename Arg>
+  struct function_traits<R (C::*)(Arg)>
+  {
+    using message_type = std::decay_t<Arg>;
+  };
+  // std::function
+  template <typename R, typename Arg>
+  struct function_traits<std::function<R(Arg)>>
+  {
+    using message_type = std::decay_t<Arg>;
+  };
+  // Generic functor/lambda
+  template <typename T>
+  struct function_traits : function_traits<decltype(&T::operator())>
+  {
+  };
 
-    template <typename T>
-    bool has_visitor() const noexcept {
-        static_assert(supports<T>(),
-                      "Type not registered");
-        return get_visitor<T>().has_value();
-    }
+  template <typename MessageType, typename VisitorFunc>
+  void register_visitor_impl(VisitorFunc && visitor)
+  {
+    static_assert(
+      (std::is_same_v<MessageType, MsgT> || ...),
+      "MessageType must be one of the "
+      "DiagnosticsVisitorRegistry template parameters");
 
-    template <typename Callable>
-    void for_each_supported(Callable&& c) const {
-        (static_cast<void>(
-             std::forward<Callable>(c).template operator()<MsgT>()),
-         ...);
-    }
+    using ReturnType = std::invoke_result_t<VisitorFunc, const MessageType &>;
+    using ExpectedReturnType = std::vector<diagnostic_msgs::msg::KeyValue>;
+    static_assert(
+      std::is_convertible_v<ReturnType, ExpectedReturnType>,
+      "Visitor must return std::vector<diagnostic_msgs::msg::KeyValue>");
 
-    template <typename Callable>
-    void for_each_registered(Callable&& c) const {
-        (void)std::initializer_list<int>{
-            (get_visitor<MsgT>().has_value()
-                 ? (std::forward<Callable>(c).template operator()<MsgT>(), 0)
-                 : 0)...};
-    }
+    VisitorFunction<MessageType> typed_visitor = std::forward<VisitorFunc>(visitor);
+    std::get<std::optional<VisitorFunction<MessageType>>>(visitors_) = std::move(typed_visitor);
+  }
 
-   private:
+  template <typename MessageType>
+  const std::optional<VisitorFunction<MessageType>> & get_visitor() const
+  {
+    static_assert(
+      (std::is_same_v<MessageType, MsgT> || ...),
+      "MessageType must be one of the "
+      "DiagnosticsVisitorRegistry template parameters");
 
-    std::tuple<std::optional<VisitorFunction<MsgT>>...> visitors_;
+    return std::get<std::optional<VisitorFunction<MessageType>>>(visitors_);
+  }
 
-    // Private helper types for lambda type deduction
-    template <typename T>
-    struct function_traits;
+  template <typename MessageType, typename VisitorFunc>
+  void register_from_helper(visitor_registration<MessageType, VisitorFunc> && reg)
+  {
+    register_visitor_impl<MessageType>(std::move(reg.visitor));
+  }
 
-    template <typename R, typename Arg>
-    struct function_traits<R (*)(Arg)> {
-        using message_type = std::decay_t<Arg>;
-    };
+  template <typename VisitorFunc>
+  void register_from_lambda(VisitorFunc && visitor_func)
+  {
+    using MessageType = typename function_traits<std::decay_t<VisitorFunc>>::message_type;
+    static_assert(
+      (std::is_same_v<MessageType, MsgT> || ...),
+      "Lambda message type must be one of the "
+      "DiagnosticsVisitorRegistry template parameters");
 
-    template <typename R, typename C, typename Arg>
-    struct function_traits<R (C::*)(Arg) const> {
-        using message_type = std::decay_t<Arg>;
-    };
+    register_visitor_impl<MessageType>(std::forward<VisitorFunc>(visitor_func));
+  }
 
-    template <typename Lambda>
-    struct function_traits : function_traits<decltype(&Lambda::operator())> {};
+  template <typename MessageType>
+  const std::vector<diagnostic_msgs::msg::KeyValue> & default_analysis() const noexcept
+  {
+    const static std::vector<diagnostic_msgs::msg::KeyValue> empty;
+    return empty;
+  }
 
-    template <typename MessageType, typename VisitorFunc>
-    void register_visitor_impl(VisitorFunc&& visitor) {
-        static_assert((std::is_same_v<MessageType, MsgT> || ...),
-                      "MessageType must be one of the "
-                      "DiagnosticsVisitorRegistry template parameters");
+  template <typename MessageType, typename VisitorFunc>
+  void register_any_visitor(visitor_registration<MessageType, VisitorFunc> && reg)
+  {
+    register_from_helper(std::move(reg));
+  }
 
-        using ReturnType =
-            std::invoke_result_t<VisitorFunc, const MessageType&>;
-        using ExpectedReturnType = std::vector<diagnostic_msgs::msg::KeyValue>;
-        static_assert(
-            std::is_convertible_v<ReturnType, ExpectedReturnType>,
-            "Visitor must return std::vector<diagnostic_msgs::msg::KeyValue>");
-
-        VisitorFunction<MessageType> typed_visitor =
-            std::forward<VisitorFunc>(visitor);
-        std::get<std::optional<VisitorFunction<MessageType>>>(visitors_) =
-            std::move(typed_visitor);
-    }
-
-
-    template <typename MessageType>
-    const std::optional<VisitorFunction<MessageType>>& get_visitor() const {
-        static_assert((std::is_same_v<MessageType, MsgT> || ...),
-                      "MessageType must be one of the "
-                      "DiagnosticsVisitorRegistry template parameters");
-
-        return std::get<std::optional<VisitorFunction<MessageType>>>(visitors_);
-    }
-
-    template <typename MessageType, typename VisitorFunc>
-    void register_from_helper(
-        visitor_registration<MessageType, VisitorFunc>&& reg) {
-        register_visitor_impl<MessageType>(std::move(reg.visitor));
-    }
-
-    template <typename VisitorFunc>
-    void register_from_lambda(VisitorFunc&& visitor_func) {
-        using MessageType =
-            typename function_traits<std::decay_t<VisitorFunc>>::message_type;
-        static_assert((std::is_same_v<MessageType, MsgT> || ...),
-                      "Lambda message type must be one of the "
-                      "DiagnosticsVisitorRegistry template parameters");
-
-        register_visitor_impl<MessageType>(std::forward<VisitorFunc>(visitor_func));
-    }
-
-    template <typename MessageType>
-    const std::vector<diagnostic_msgs::msg::KeyValue>& default_analysis()
-        const noexcept {
-        const static std::vector<diagnostic_msgs::msg::KeyValue> empty;
-        return empty;
-    }
-
-    template <typename MessageType, typename VisitorFunc>
-    void register_any_visitor(
-        visitor_registration<MessageType, VisitorFunc>&& reg) {
-        register_from_helper(std::move(reg));
-    }
-
-    template <typename VisitorFunc>
-    void register_any_visitor(VisitorFunc&& visitor_func) {
-        register_visitor(std::forward<VisitorFunc>(visitor_func));
-    }
+  template <typename VisitorFunc>
+  void register_any_visitor(VisitorFunc && visitor_func)
+  {
+    register_visitor(std::forward<VisitorFunc>(visitor_func));
+  }
 };
 
 template <typename... MsgT, typename... VisitorRegs>
-DiagnosticsVisitorRegistry<MsgT...> make_visitor_registry(
-    VisitorRegs&&... visitor_regs) {
-    return DiagnosticsVisitorRegistry<MsgT...>(
-        std::forward<VisitorRegs>(visitor_regs)...);
+DiagnosticsVisitorRegistry<MsgT...> make_visitor_registry(VisitorRegs &&... visitor_regs)
+{
+  return DiagnosticsVisitorRegistry<MsgT...>(std::forward<VisitorRegs>(visitor_regs)...);
 }
 
 }  // namespace ouster_ros

--- a/ouster-ros/include/ouster_ros/ring_buffer.h
+++ b/ouster-ros/include/ouster_ros/ring_buffer.h
@@ -67,17 +67,6 @@ class RingBuffer {
         return buffer_.end();
     }
 
-    void set_capacity(std::size_t new_capacity) {
-        capacity_ = new_capacity;
-        while(buffer_.size() > capacity_) {
-            buffer_.pop_front();
-        }
-    }
-
-    std::size_t capacity() const {
-        return capacity_;
-    }
-
   private:
     std::deque<T> buffer_;
     std::size_t capacity_;

--- a/ouster-ros/include/ouster_ros/ring_buffer.h
+++ b/ouster-ros/include/ouster_ros/ring_buffer.h
@@ -1,3 +1,12 @@
+/**
+ * Copyright (c) 2023-2025, Autonomous Systems sp. z o.o.
+ * All rights reserved.
+ *
+ * @file os_sensor_node_base.h
+ * @brief Base class for ouster_ros sensor and replay nodes
+ *
+ */
+
 #pragma once
 #include <deque>
 

--- a/ouster-ros/include/ouster_ros/ring_buffer.h
+++ b/ouster-ros/include/ouster_ros/ring_buffer.h
@@ -1,0 +1,75 @@
+#pragma once
+#include <deque>
+
+template <typename T>
+class RingBuffer {
+  public:
+    explicit RingBuffer(std::size_t capacity = 100) : capacity_(capacity) {}
+
+    void push_back(const T& item) {
+        if(buffer_.size() >= capacity_) {
+            buffer_.pop_front();
+        }
+        buffer_.push_back(item);
+    }
+
+    void push_back(T&& item) {
+        if(buffer_.size() >= capacity_) {
+            buffer_.pop_front();
+        }
+        buffer_.push_back(std::move(item));
+    }
+
+    void clear() {
+        buffer_.clear();
+    }
+
+    std::size_t size() const {
+        return buffer_.size();
+    }
+
+    bool empty() const {
+        return buffer_.empty();
+    }
+
+    const T& operator[](std::size_t index) const {
+        return buffer_[index];
+    }
+
+    const T& back() const {
+        return buffer_.back();
+    }
+
+    const T& front() const {
+        return buffer_.front();
+    }
+
+    // Iterator support
+    auto begin() const {
+        return buffer_.begin();
+    }
+    auto end() const {
+        return buffer_.end();
+    }
+    auto begin() {
+        return buffer_.begin();
+    }
+    auto end() {
+        return buffer_.end();
+    }
+
+    void set_capacity(std::size_t new_capacity) {
+        capacity_ = new_capacity;
+        while(buffer_.size() > capacity_) {
+            buffer_.pop_front();
+        }
+    }
+
+    std::size_t capacity() const {
+        return capacity_;
+    }
+
+  private:
+    std::deque<T> buffer_;
+    std::size_t capacity_;
+};

--- a/ouster-ros/include/ouster_ros/sensor_diagnostics_tracker.h
+++ b/ouster-ros/include/ouster_ros/sensor_diagnostics_tracker.h
@@ -9,6 +9,8 @@
 #pragma once
 
 #include <ouster/types.h>
+#include <ouster_ros/diagnostics_visitor_registry.h>
+#include <ouster_ros/ring_buffer.h>
 
 #include <cstdint>
 #include <diagnostic_msgs/msg/diagnostic_status.hpp>
@@ -23,10 +25,10 @@
 namespace ouster_ros
 {
 
-class SensorDiagnosticsTracker final
+class SensorDiagnosticsState final
 {
 public:
-  SensorDiagnosticsTracker  (
+  SensorDiagnosticsState(
     const std::string & name, rclcpp::Clock::SharedPtr clock, const std::string & hardware_id = "")
   : name_{name},
     hardware_id_{hardware_id.empty() ? name : hardware_id},
@@ -34,6 +36,8 @@ public:
     sensor_start_time_{clock_->now()}
   {
   }
+
+  ~SensorDiagnosticsState() = default;
 
   void record_lidar_packet();
   void record_imu_packet();
@@ -97,6 +101,8 @@ protected:
   uint32_t read_imu_packet_errors_{0};
   std::map<std::string, std::string> sensor_info_;
 
+  std::map<std::string, RingBuffer<std::vector<diagnostic_msgs::msg::KeyValue>>> message_history_;
+
   std::string current_message_{"Not initialized"};
   diagnostic_msgs::msg::DiagnosticStatus::_level_type current_level_{
     diagnostic_msgs::msg::DiagnosticStatus::STALE};
@@ -105,5 +111,210 @@ protected:
 private:
   rclcpp::Time get_zero_time() const;
 };
+
+template <
+  typename DiagnosticsVisitorRegistryType>
+class SensorDiagnosticsTracker
+{
+public:
+  using DiagnosticsVisitorRegistryT = DiagnosticsVisitorRegistryType;
+
+  template <typename NodeT>
+  SensorDiagnosticsTracker(
+    const std::string & name, NodeT * node, const std::string & hardware_id = "",
+    const DiagnosticsVisitorRegistryType & msg_analyzer = DiagnosticsVisitorRegistryType{});
+
+  SensorDiagnosticsTracker(
+    const std::string & name, rclcpp::Clock::SharedPtr clock, const std::string & hardware_id = "",
+    const DiagnosticsVisitorRegistryType & msg_analyzer = DiagnosticsVisitorRegistryType{});
+
+  ~SensorDiagnosticsTracker() = default;
+
+  void record_lidar_packet() { base_.record_lidar_packet(); }
+  void record_imu_packet() { base_.record_imu_packet(); }
+  void increment_poll_client_errors() { base_.increment_poll_client_errors(); }
+  void increment_lidar_packet_errors() { base_.increment_lidar_packet_errors(); }
+  void increment_imu_packet_errors() { base_.increment_imu_packet_errors(); }
+  void notify_reset_sensor() { base_.notify_reset_sensor(); }
+  void update_metadata(const ouster::sensor::sensor_info & info) { base_.update_metadata(info); }
+
+  void force_update();
+
+  void update_status(
+    const std::string & message, diagnostic_msgs::msg::DiagnosticStatus::_level_type level,
+    const std::map<std::string, std::string> & debug_context = {});
+
+  diagnostic_msgs::msg::DiagnosticStatus get_current_status() const;
+
+  std::map<std::string, std::string> get_debug_context(
+    const std::string & sensor_hostname, bool sensor_connection_active) const;
+
+  diagnostic_msgs::msg::DiagnosticStatus create_diagnostic_status(
+    const std::string & message, diagnostic_msgs::msg::DiagnosticStatus::_level_type level,
+    const std::map<std::string, std::string> & debug_context = {}) const;
+
+  template <typename MsgT>
+  void record_msg(const std::string & topic_name, const MsgT & msgs);
+
+private:
+  void produce_diagnostics(diagnostic_updater::DiagnosticStatusWrapper & stat);
+
+  double get_packet_rate(uint32_t packet_count, const rclcpp::Time & start_time) const;
+  bool is_sensor_healthy() const;
+
+  rclcpp::Logger logger_;
+  std::unique_ptr<diagnostic_updater::Updater> updater_;
+
+  // Current sensor status
+  std::string sensor_hostname_{"unknown"};
+  bool sensor_connection_active_{false};
+
+  SensorDiagnosticsState base_;
+  DiagnosticsVisitorRegistryType msg_analyzer_;
+};
+
+// Template implementation for ROS nodes
+template <typename DiagnosticsVisitorRegistryType>
+template <typename NodeT>
+SensorDiagnosticsTracker<DiagnosticsVisitorRegistryType>::SensorDiagnosticsTracker(
+  const std::string & name, NodeT * node, const std::string & hardware_id,
+  const DiagnosticsVisitorRegistryType & msg_analyzer)
+: logger_(node->get_logger()),
+  updater_(nullptr),
+  base_(name, node->get_clock(), hardware_id),
+  msg_analyzer_(msg_analyzer)
+{
+  try {
+    updater_ = std::make_unique<diagnostic_updater::Updater>(node);
+    updater_->setHardwareID(base_.get_hardware_id());
+    updater_->add(name + " Status", this, &SensorDiagnosticsTracker::produce_diagnostics);
+    RCLCPP_INFO(logger_, "Diagnostic updater initialized for %s", name.c_str());
+  } catch (const std::exception & e) {
+    RCLCPP_WARN(logger_, "Failed to initialize diagnostic updater: %s", e.what());
+    updater_ = nullptr;
+  }
+}
+
+// Standalone constructor for testing
+template <typename DiagnosticsVisitorRegistryType>
+SensorDiagnosticsTracker<DiagnosticsVisitorRegistryType>::SensorDiagnosticsTracker(
+  const std::string & name, rclcpp::Clock::SharedPtr clock, const std::string & hardware_id,
+  const DiagnosticsVisitorRegistryType & msg_analyzer)
+: logger_(rclcpp::get_logger("sensor_diagnostics_tracker")),
+  updater_(nullptr),
+  base_(name, clock, hardware_id),
+  msg_analyzer_(msg_analyzer)
+{
+  RCLCPP_INFO(logger_, "Standalone sensor diagnostics tracker initialized for %s", name.c_str());
+}
+
+template <typename DiagnosticsVisitorRegistryType>
+void SensorDiagnosticsTracker<DiagnosticsVisitorRegistryType>::force_update()
+{
+  if (updater_) {
+    updater_->force_update();
+  }
+}
+
+template <typename DiagnosticsVisitorRegistryType>
+void SensorDiagnosticsTracker<DiagnosticsVisitorRegistryType>::update_status(
+  const std::string & message, diagnostic_msgs::msg::DiagnosticStatus::_level_type level,
+  const std::map<std::string, std::string> & debug_context)
+{
+  base_.update_status(message, level, debug_context);
+}
+
+template <typename DiagnosticsVisitorRegistryType>
+diagnostic_msgs::msg::DiagnosticStatus
+SensorDiagnosticsTracker<DiagnosticsVisitorRegistryType>::get_current_status() const
+{
+  return base_.get_current_status();
+}
+
+template <typename DiagnosticsVisitorRegistryType>
+std::map<std::string, std::string>
+SensorDiagnosticsTracker<DiagnosticsVisitorRegistryType>::get_debug_context(
+  const std::string & sensor_hostname, bool sensor_connection_active) const
+{
+  return base_.get_debug_context(sensor_hostname, sensor_connection_active);
+}
+
+template <typename DiagnosticsVisitorRegistryType>
+diagnostic_msgs::msg::DiagnosticStatus
+SensorDiagnosticsTracker<DiagnosticsVisitorRegistryType>::create_diagnostic_status(
+  const std::string & message, diagnostic_msgs::msg::DiagnosticStatus::_level_type level,
+  const std::map<std::string, std::string> & debug_context) const
+{
+  return base_.create_diagnostic_status(message, level, debug_context);
+}
+
+template <typename DiagnosticsVisitorRegistryType>
+template <typename MsgT>
+void SensorDiagnosticsTracker<DiagnosticsVisitorRegistryType>::record_msg(
+  const std::string & topic_name, const MsgT & msgs)
+{
+  auto analysis = msg_analyzer_(msgs);
+  base_.add_message_analysis(topic_name, analysis);
+}
+
+template <typename DiagnosticsVisitorRegistryType>
+void SensorDiagnosticsTracker<DiagnosticsVisitorRegistryType>::produce_diagnostics(
+  diagnostic_updater::DiagnosticStatusWrapper & stat)
+{
+  bool is_healthy = is_sensor_healthy();
+
+  if (is_healthy) {
+    stat.summary(diagnostic_msgs::msg::DiagnosticStatus::OK, "Sensor operating normally");
+  } else {
+    stat.summary(diagnostic_msgs::msg::DiagnosticStatus::WARN, "Sensor health issues detected");
+  }
+
+  const auto & current_status = base_.get_current_status();
+  auto diag_status = create_diagnostic_status(
+    current_status.message, current_status.level,
+    base_.get_debug_context(sensor_hostname_, sensor_connection_active_));
+  std::move(diag_status.values.begin(), diag_status.values.end(), std::back_inserter(stat.values));
+}
+
+template <typename DiagnosticsVisitorRegistryType>
+bool SensorDiagnosticsTracker<DiagnosticsVisitorRegistryType>::is_sensor_healthy() const
+{
+  auto now = base_.get_clock()->now();
+
+  // Check if we've received recent packets
+  const auto timeout_threshold = rclcpp::Duration::from_seconds(5.0);
+
+  bool lidar_healthy = (now - base_.get_last_successful_lidar_frame()) < timeout_threshold;
+  bool imu_healthy = (now - base_.get_last_successful_imu_frame()) < timeout_threshold;
+
+  // Consider sensor healthy if we have recent data and low error rates
+  bool low_error_rate = (base_.get_poll_client_error_count() < 10) &&
+                        (base_.get_read_lidar_packet_errors() < 100) &&
+                        (base_.get_read_imu_packet_errors() < 100);
+
+  return (lidar_healthy || imu_healthy) && low_error_rate;
+}
+
+template <typename DiagnosticsVisitorRegistryType>
+double SensorDiagnosticsTracker<DiagnosticsVisitorRegistryType>::get_packet_rate(
+  uint32_t packet_count, const rclcpp::Time & start_time) const
+{
+  auto now = base_.get_clock()->now();
+  auto duration = now - start_time;
+  if (duration.seconds() > 0) {
+    return static_cast<double>(packet_count) / duration.seconds();
+  }
+  return 0.0;
+}
+
+// Helper function to create trackers with message analyzers
+template <typename DiagnosticsVisitorRegistryType>
+auto make_sensor_diagnostics_tracker(
+  const std::string & name, rclcpp::Node * node, const std::string & hardware_id,
+  const DiagnosticsVisitorRegistryType & msg_analyzer)
+{
+  return SensorDiagnosticsTracker<DiagnosticsVisitorRegistryType>(
+    name, node, hardware_id, msg_analyzer);
+}
 
 }  // namespace ouster_ros

--- a/ouster-ros/include/ouster_ros/sensor_diagnostics_tracker.h
+++ b/ouster-ros/include/ouster_ros/sensor_diagnostics_tracker.h
@@ -184,15 +184,10 @@ SensorDiagnosticsTracker<DiagnosticsVisitorRegistryType>::SensorDiagnosticsTrack
   base_(name, node->get_clock(), hardware_id),
   msg_analyzer_(msg_analyzer)
 {
-  try {
     updater_ = std::make_unique<diagnostic_updater::Updater>(node);
     updater_->setHardwareID(base_.get_hardware_id());
     updater_->add(name + " Status", this, &SensorDiagnosticsTracker::produce_diagnostics);
     RCLCPP_INFO(logger_, "Diagnostic updater initialized for %s", name.c_str());
-  } catch (const std::exception & e) {
-    RCLCPP_WARN(logger_, "Failed to initialize diagnostic updater: %s", e.what());
-    updater_ = nullptr;
-  }
 }
 
 // Standalone constructor for testing

--- a/ouster-ros/include/ouster_ros/sensor_diagnostics_tracker.hpp
+++ b/ouster-ros/include/ouster_ros/sensor_diagnostics_tracker.hpp
@@ -1,0 +1,320 @@
+/**
+ * Copyright (c) 2018-2023, Ouster, Inc.
+ * All rights reserved.
+ *
+ * @file sensor_diagnostics_tracker.h
+ * @brief Diagnostic tracking functionality for Ouster sensors using ROS2 diagnostic_updater with message analysis
+ */
+
+#pragma once
+
+#include <ouster/types.h>
+#include <ouster_ros/diagnostics_visitor_registry.h>
+#include <ouster_ros/ring_buffer.h>
+
+#include <cstdint>
+#include <diagnostic_msgs/msg/diagnostic_status.hpp>
+#include <diagnostic_msgs/msg/key_value.hpp>
+#include <diagnostic_updater/diagnostic_updater.hpp>
+#include <map>
+#include <rclcpp/clock.hpp>
+#include <rclcpp/logger.hpp>
+#include <rclcpp/rclcpp.hpp>
+#include <string>
+
+namespace ouster_ros
+{
+
+class SensorDiagnosticsState final
+{
+public:
+  SensorDiagnosticsState(
+    const std::string & name, rclcpp::Clock::SharedPtr clock, const std::string & hardware_id = "")
+  : name_{name},
+    hardware_id_{hardware_id.empty() ? name : hardware_id},
+    clock_{clock},
+    sensor_start_time_{clock_->now()}
+  {
+  }
+
+  ~SensorDiagnosticsState() = default;
+
+  void record_lidar_packet();
+  void record_imu_packet();
+  void increment_poll_client_errors();
+  void increment_lidar_packet_errors();
+  void increment_imu_packet_errors();
+  void notify_reset_sensor();
+  void update_metadata(const ouster::sensor::sensor_info & info);
+
+  std::map<std::string, std::string> get_debug_context(
+    const std::string & sensor_hostname, bool sensor_connection_active) const;
+
+  diagnostic_msgs::msg::DiagnosticStatus create_diagnostic_status(
+    const std::string & message, diagnostic_msgs::msg::DiagnosticStatus::_level_type level,
+    const std::map<std::string, std::string> & debug_context = {}) const;
+
+  void update_status(
+    const std::string & message, diagnostic_msgs::msg::DiagnosticStatus::_level_type level,
+    const std::map<std::string, std::string> & debug_context = {});
+
+  diagnostic_msgs::msg::DiagnosticStatus get_current_status() const;
+
+  void add_message_analysis(
+    const std::string & topic_name, const std::vector<diagnostic_msgs::msg::KeyValue> & analysis);
+
+  const std::string & get_hardware_id() const { return hardware_id_; }
+  rclcpp::Clock::SharedPtr get_clock() const { return clock_; }
+  const rclcpp::Time & get_sensor_start_time() const { return sensor_start_time_; }
+  uint32_t get_total_lidar_packets() const { return total_lidar_packets_received_; }
+  uint32_t get_total_imu_packets() const { return total_imu_packets_received_; }
+  uint32_t get_total_sensor_resets() const { return total_sensor_resets_; }
+  uint32_t get_poll_client_error_count() const { return poll_client_error_count_; }
+  uint32_t get_read_lidar_packet_errors() const { return read_lidar_packet_errors_; }
+  uint32_t get_read_imu_packet_errors() const { return read_imu_packet_errors_; }
+  const std::map<std::string, std::string> & get_sensor_info() const { return sensor_info_; }
+  const rclcpp::Time & get_last_successful_lidar_frame() const
+  {
+    return last_successful_lidar_frame_;
+  }
+  const rclcpp::Time & get_last_successful_imu_frame() const { return last_successful_imu_frame_; }
+
+protected:
+  std::string name_;
+  std::string hardware_id_;
+  rclcpp::Clock::SharedPtr clock_;
+
+  rclcpp::Time sensor_start_time_;
+  rclcpp::Time last_successful_lidar_frame_;
+  rclcpp::Time last_successful_imu_frame_;
+  rclcpp::Time last_unsuccessful_lidar_frame_;
+  rclcpp::Time last_unsuccessful_imu_frame_;
+  rclcpp::Time last_client_error_;
+  rclcpp::Time last_sensor_reset_;
+
+  uint32_t total_lidar_packets_received_{0};
+  uint32_t total_imu_packets_received_{0};
+  uint32_t total_sensor_resets_{0};
+
+  uint32_t poll_client_error_count_{0};
+  uint32_t read_lidar_packet_errors_{0};
+  uint32_t read_imu_packet_errors_{0};
+  std::map<std::string, std::string> sensor_info_;
+
+  std::map<std::string, RingBuffer<std::vector<diagnostic_msgs::msg::KeyValue>>> message_history_;
+
+  std::string current_message_{"Not initialized"};
+  diagnostic_msgs::msg::DiagnosticStatus::_level_type current_level_{
+    diagnostic_msgs::msg::DiagnosticStatus::STALE};
+  std::map<std::string, std::string> current_debug_context_;
+
+private:
+  rclcpp::Time get_zero_time() const;
+};
+
+template <
+  typename DiagnosticsVisitorRegistryType>
+class SensorDiagnosticsTracker
+{
+public:
+  using DiagnosticsVisitorRegistryT = DiagnosticsVisitorRegistryType;
+
+  template <typename NodeT>
+  SensorDiagnosticsTracker(
+    const std::string & name, NodeT * node, const std::string & hardware_id = "",
+    const DiagnosticsVisitorRegistryType & msg_analyzer = DiagnosticsVisitorRegistryType{});
+
+  SensorDiagnosticsTracker(
+    const std::string & name, rclcpp::Clock::SharedPtr clock, const std::string & hardware_id = "",
+    const DiagnosticsVisitorRegistryType & msg_analyzer = DiagnosticsVisitorRegistryType{});
+
+  ~SensorDiagnosticsTracker() = default;
+
+  void record_lidar_packet() { base_.record_lidar_packet(); }
+  void record_imu_packet() { base_.record_imu_packet(); }
+  void increment_poll_client_errors() { base_.increment_poll_client_errors(); }
+  void increment_lidar_packet_errors() { base_.increment_lidar_packet_errors(); }
+  void increment_imu_packet_errors() { base_.increment_imu_packet_errors(); }
+  void notify_reset_sensor() { base_.notify_reset_sensor(); }
+  void update_metadata(const ouster::sensor::sensor_info & info) { base_.update_metadata(info); }
+
+  void force_update();
+
+  void update_status(
+    const std::string & message, diagnostic_msgs::msg::DiagnosticStatus::_level_type level,
+    const std::map<std::string, std::string> & debug_context = {});
+
+  diagnostic_msgs::msg::DiagnosticStatus get_current_status() const;
+
+  std::map<std::string, std::string> get_debug_context(
+    const std::string & sensor_hostname, bool sensor_connection_active) const;
+
+  diagnostic_msgs::msg::DiagnosticStatus create_diagnostic_status(
+    const std::string & message, diagnostic_msgs::msg::DiagnosticStatus::_level_type level,
+    const std::map<std::string, std::string> & debug_context = {}) const;
+
+  template <typename MsgT>
+  void record_msg(const std::string & topic_name, const MsgT & msgs);
+
+private:
+  void produce_diagnostics(diagnostic_updater::DiagnosticStatusWrapper & stat);
+
+  double get_packet_rate(uint32_t packet_count, const rclcpp::Time & start_time) const;
+  bool is_sensor_healthy() const;
+
+  rclcpp::Logger logger_;
+  std::unique_ptr<diagnostic_updater::Updater> updater_;
+
+  // Current sensor status
+  std::string sensor_hostname_{"unknown"};
+  bool sensor_connection_active_{false};
+
+  SensorDiagnosticsState base_;
+  DiagnosticsVisitorRegistryType msg_analyzer_;
+};
+
+// Template implementation for ROS nodes
+template <typename DiagnosticsVisitorRegistryType>
+template <typename NodeT>
+SensorDiagnosticsTracker<DiagnosticsVisitorRegistryType>::SensorDiagnosticsTracker(
+  const std::string & name, NodeT * node, const std::string & hardware_id,
+  const DiagnosticsVisitorRegistryType & msg_analyzer)
+: logger_(node->get_logger()),
+  updater_(nullptr),
+  base_(name, node->get_clock(), hardware_id),
+  msg_analyzer_(msg_analyzer)
+{
+  try {
+    updater_ = std::make_unique<diagnostic_updater::Updater>(node);
+    updater_->setHardwareID(base_.get_hardware_id());
+    updater_->add(name + " Status", this, &SensorDiagnosticsTracker::produce_diagnostics);
+    RCLCPP_INFO(logger_, "Diagnostic updater initialized for %s", name.c_str());
+  } catch (const std::exception & e) {
+    RCLCPP_WARN(logger_, "Failed to initialize diagnostic updater: %s", e.what());
+    updater_ = nullptr;
+  }
+}
+
+// Standalone constructor for testing
+template <typename DiagnosticsVisitorRegistryType>
+SensorDiagnosticsTracker<DiagnosticsVisitorRegistryType>::SensorDiagnosticsTracker(
+  const std::string & name, rclcpp::Clock::SharedPtr clock, const std::string & hardware_id,
+  const DiagnosticsVisitorRegistryType & msg_analyzer)
+: logger_(rclcpp::get_logger("sensor_diagnostics_tracker")),
+  updater_(nullptr),
+  base_(name, clock, hardware_id),
+  msg_analyzer_(msg_analyzer)
+{
+  RCLCPP_INFO(logger_, "Standalone sensor diagnostics tracker initialized for %s", name.c_str());
+}
+
+template <typename DiagnosticsVisitorRegistryType>
+void SensorDiagnosticsTracker<DiagnosticsVisitorRegistryType>::force_update()
+{
+  if (updater_) {
+    updater_->force_update();
+  }
+}
+
+template <typename DiagnosticsVisitorRegistryType>
+void SensorDiagnosticsTracker<DiagnosticsVisitorRegistryType>::update_status(
+  const std::string & message, diagnostic_msgs::msg::DiagnosticStatus::_level_type level,
+  const std::map<std::string, std::string> & debug_context)
+{
+  base_.update_status(message, level, debug_context);
+}
+
+template <typename DiagnosticsVisitorRegistryType>
+diagnostic_msgs::msg::DiagnosticStatus
+SensorDiagnosticsTracker<DiagnosticsVisitorRegistryType>::get_current_status() const
+{
+  return base_.get_current_status();
+}
+
+template <typename DiagnosticsVisitorRegistryType>
+std::map<std::string, std::string>
+SensorDiagnosticsTracker<DiagnosticsVisitorRegistryType>::get_debug_context(
+  const std::string & sensor_hostname, bool sensor_connection_active) const
+{
+  return base_.get_debug_context(sensor_hostname, sensor_connection_active);
+}
+
+template <typename DiagnosticsVisitorRegistryType>
+diagnostic_msgs::msg::DiagnosticStatus
+SensorDiagnosticsTracker<DiagnosticsVisitorRegistryType>::create_diagnostic_status(
+  const std::string & message, diagnostic_msgs::msg::DiagnosticStatus::_level_type level,
+  const std::map<std::string, std::string> & debug_context) const
+{
+  return base_.create_diagnostic_status(message, level, debug_context);
+}
+
+template <typename DiagnosticsVisitorRegistryType>
+template <typename MsgT>
+void SensorDiagnosticsTracker<DiagnosticsVisitorRegistryType>::record_msg(
+  const std::string & topic_name, const MsgT & msgs)
+{
+  auto analysis = msg_analyzer_(msgs);
+  base_.add_message_analysis(topic_name, analysis);
+}
+
+template <typename DiagnosticsVisitorRegistryType>
+void SensorDiagnosticsTracker<DiagnosticsVisitorRegistryType>::produce_diagnostics(
+  diagnostic_updater::DiagnosticStatusWrapper & stat)
+{
+  bool is_healthy = is_sensor_healthy();
+
+  if (is_healthy) {
+    stat.summary(diagnostic_msgs::msg::DiagnosticStatus::OK, "Sensor operating normally");
+  } else {
+    stat.summary(diagnostic_msgs::msg::DiagnosticStatus::WARN, "Sensor health issues detected");
+  }
+
+  const auto & current_status = base_.get_current_status();
+  auto diag_status = create_diagnostic_status(
+    current_status.message, current_status.level,
+    base_.get_debug_context(sensor_hostname_, sensor_connection_active_));
+  std::move(diag_status.values.begin(), diag_status.values.end(), std::back_inserter(stat.values));
+}
+
+template <typename DiagnosticsVisitorRegistryType>
+bool SensorDiagnosticsTracker<DiagnosticsVisitorRegistryType>::is_sensor_healthy() const
+{
+  auto now = base_.get_clock()->now();
+
+  // Check if we've received recent packets
+  const auto timeout_threshold = rclcpp::Duration::from_seconds(5.0);
+
+  bool lidar_healthy = (now - base_.get_last_successful_lidar_frame()) < timeout_threshold;
+  bool imu_healthy = (now - base_.get_last_successful_imu_frame()) < timeout_threshold;
+
+  // Consider sensor healthy if we have recent data and low error rates
+  bool low_error_rate = (base_.get_poll_client_error_count() < 10) &&
+                        (base_.get_read_lidar_packet_errors() < 100) &&
+                        (base_.get_read_imu_packet_errors() < 100);
+
+  return (lidar_healthy || imu_healthy) && low_error_rate;
+}
+
+template <typename DiagnosticsVisitorRegistryType>
+double SensorDiagnosticsTracker<DiagnosticsVisitorRegistryType>::get_packet_rate(
+  uint32_t packet_count, const rclcpp::Time & start_time) const
+{
+  auto now = base_.get_clock()->now();
+  auto duration = now - start_time;
+  if (duration.seconds() > 0) {
+    return static_cast<double>(packet_count) / duration.seconds();
+  }
+  return 0.0;
+}
+
+// Helper function to create trackers with message analyzers
+template <typename DiagnosticsVisitorRegistryType>
+auto make_sensor_diagnostics_tracker(
+  const std::string & name, rclcpp::Node * node, const std::string & hardware_id,
+  const DiagnosticsVisitorRegistryType & msg_analyzer)
+{
+  return SensorDiagnosticsTracker<DiagnosticsVisitorRegistryType>(
+    name, node, hardware_id, msg_analyzer);
+}
+
+}  // namespace ouster_ros

--- a/ouster-ros/src/msg_analyzers.cpp
+++ b/ouster-ros/src/msg_analyzers.cpp
@@ -29,7 +29,7 @@ auto to_sec(const MsgWithHeaderT& time) {
 }
 
 inline std::string to_string(const builtin_interfaces::msg::Time& header) {
-    auto time = to_sec(header);
+    const auto time = to_sec(header);
     return std::to_string(time.count());
 }
 

--- a/ouster-ros/src/msg_analyzers.cpp
+++ b/ouster-ros/src/msg_analyzers.cpp
@@ -1,0 +1,101 @@
+/**
+ * Copyright (c) 2018-2025, Ouster, Inc.
+ * All rights reserved.
+ *
+ * @file msg_analyzers.cpp
+ * @brief Implementation of message analysis utilities for Ouster sensors
+ */
+#include "msg_analyzers.h"
+#include <chrono>
+#include <rclcpp/duration.hpp>
+#include <rclcpp/node.hpp>
+#include <sensor_msgs/msg/detail/image__struct.hpp>
+#include <sensor_msgs/msg/detail/point_cloud2__struct.hpp>
+#include <string>
+
+namespace ouster_ros {
+
+
+inline diagnostic_msgs::msg::KeyValue to_kv(const std::string& key, const std::string& value) {
+    diagnostic_msgs::msg::KeyValue kv;
+    kv.key = key;
+    kv.value = value;
+    return kv;
+}
+
+template <typename MsgWithHeaderT>
+auto to_sec(const MsgWithHeaderT& time) {
+    return std::chrono::seconds(time.sec) + std::chrono::nanoseconds(time.nanosec);
+}
+
+inline std::string to_string(const builtin_interfaces::msg::Time& header) {
+    return std::to_string(header.sec) + "." + std::to_string(header.nanosec);
+}
+
+template <typename MsgT>
+std::vector<diagnostic_msgs::msg::KeyValue> add_timestamp(const MsgT& msg) {
+    std::vector<diagnostic_msgs::msg::KeyValue> key_values;
+    key_values.emplace_back(to_kv("timestamp", to_string(msg.header.stamp)));
+    return key_values;
+}
+
+
+std::vector<diagnostic_msgs::msg::KeyValue> analyze_msg(const sensor_msgs::msg::PointCloud2& msg) {
+    return add_timestamp(msg);
+}
+
+std::vector<diagnostic_msgs::msg::KeyValue> analyze_msg(const sensor_msgs::msg::Image& msg) {
+    return add_timestamp(msg);
+}
+
+template <typename MsgT>
+std::vector<diagnostic_msgs::msg::KeyValue> add_time_diff(const rclcpp::Clock::SharedPtr clock,
+                                                          const MsgT& msg) {
+    auto result = add_timestamp(msg);
+    if(clock) {
+        const auto current_time = clock->now();
+        const auto msg_time = msg.header.stamp;
+        const auto time_diff = current_time - msg_time;
+        result.emplace_back(to_kv("current_time", std::to_string(current_time.seconds())));
+        result.emplace_back(to_kv("time_diff", std::to_string(time_diff.seconds())));
+    }
+    return result;
+}
+
+auto time_diff(const detail::MsgTimeInfo& info) {
+    return (info.received_msg - info.msg_timestamp);
+}
+
+
+namespace detail {
+std::vector<diagnostic_msgs::msg::KeyValue>
+aggregate(const RingBuffer<MsgTimeInfo> time_info_buffer_) {
+
+    std::vector<diagnostic_msgs::msg::KeyValue> key_values;
+
+    const auto [time_diff_min, time_diff_max] = std::minmax_element(
+        time_info_buffer_.begin(), time_info_buffer_.end(),
+        [](const auto& a, const auto& b) { return time_diff(a) < time_diff(b); });
+    if(time_diff_min != time_info_buffer_.end()) {
+        key_values.emplace_back(
+            to_kv("time_diff_min", std::to_string(time_diff(*time_diff_min).seconds())));
+    }
+
+    if(time_diff_max != time_info_buffer_.end()) {
+        key_values.emplace_back(
+            to_kv("time_diff_max", std::to_string(time_diff(*time_diff_max).seconds())));
+    }
+    const auto time_diff_sum =
+        std::accumulate(time_info_buffer_.begin(), time_info_buffer_.end(), rclcpp::Duration{0, 0},
+                        [](const auto& sum, const auto& info) { return sum + time_diff(info); });
+
+    const auto time_diff_avg = time_diff_sum.seconds() / time_info_buffer_.size();
+
+    key_values.emplace_back(to_kv("time_diff_avg", std::to_string(time_diff_avg)));
+    key_values.emplace_back(to_kv("time_diff_frames", std::to_string(time_info_buffer_.size())));
+    return key_values;
+}
+
+} // namespace detail
+
+} // namespace ouster_ros

--- a/ouster-ros/src/msg_analyzers.cpp
+++ b/ouster-ros/src/msg_analyzers.cpp
@@ -29,7 +29,8 @@ auto to_sec(const MsgWithHeaderT& time) {
 }
 
 inline std::string to_string(const builtin_interfaces::msg::Time& header) {
-    return std::to_string(header.sec) + "." + std::to_string(header.nanosec);
+    auto time = to_sec(header);
+    return std::to_string(time.count());
 }
 
 template <typename MsgT>

--- a/ouster-ros/src/msg_analyzers.h
+++ b/ouster-ros/src/msg_analyzers.h
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2018-2025, Ouster, Inc.
+ * All rights reserved.
+ *
+ * @file msg_analyzers.h
+ * @brief Message analysis utilities for Ouster sensors
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <diagnostic_msgs/msg/key_value.hpp>
+#include <ouster_ros/ring_buffer.h>
+#include <rclcpp/clock.hpp>
+#include <rclcpp/time.hpp>
+#include <sensor_msgs/msg/detail/point_cloud2__struct.hpp>
+#include <sensor_msgs/msg/point_cloud2.hpp>
+#include <sensor_msgs/msg/image.hpp>
+#include <rclcpp/node.hpp>
+
+#include <vector>
+
+namespace ouster_ros {
+
+std::vector<diagnostic_msgs::msg::KeyValue> analyze_msg(const sensor_msgs::msg::PointCloud2& msg);
+std::vector<diagnostic_msgs::msg::KeyValue> analyze_msg(const sensor_msgs::msg::Image& msg);
+
+
+namespace detail {
+struct MsgTimeInfo {
+    rclcpp::Time msg_timestamp;
+    rclcpp::Time received_msg;
+};
+
+std::vector<diagnostic_msgs::msg::KeyValue>
+aggregate(const RingBuffer<MsgTimeInfo> time_info_buffer);
+} //namespace detail
+
+template <typename MsgT>
+class RosMsgAggregateTimeAnalyzer {
+  public:
+    RosMsgAggregateTimeAnalyzer() = default;
+    RosMsgAggregateTimeAnalyzer(rclcpp::Clock::SharedPtr clock) : clock_(clock) {}
+
+    std::vector<diagnostic_msgs::msg::KeyValue>
+    operator()(const MsgT& msg) {
+        detail::MsgTimeInfo time_info{msg.header.stamp, clock_->now()};
+        time_info_buffer_.push_back(time_info);
+        return detail::aggregate(time_info_buffer_);
+    }
+
+  private:
+    rclcpp::Clock::SharedPtr clock_;
+
+    RingBuffer<detail::MsgTimeInfo> time_info_buffer_;
+};
+
+
+} // namespace ouster_ros

--- a/ouster-ros/src/os_driver_node.cpp
+++ b/ouster-ros/src/os_driver_node.cpp
@@ -26,6 +26,9 @@
 
 namespace ouster_ros {
 
+using DiagnosticsMsgAnalyzer =
+  ouster_ros::DiagnosticsVisitorRegistry<sensor_msgs::msg::PointCloud2, sensor_msgs::msg::Image>;
+
 namespace sensor = ouster::sensor;
 using ouster::sensor::LidarPacket;
 using ouster::sensor::ImuPacket;

--- a/ouster-ros/src/os_sensor_node.cpp
+++ b/ouster-ros/src/os_sensor_node.cpp
@@ -14,8 +14,11 @@
 
 #include "os_sensor_node.h"
 #include "ouster_ros/sensor_diagnostics_tracker.h"
+#include "msg_analyzers.h"
 
 #include <chrono>
+#include <sensor_msgs/msg/point_cloud2.hpp>
+#include <sensor_msgs/msg/image.hpp>
 
 using ouster_sensor_msgs::msg::PacketMsg;
 using ouster_sensor_msgs::srv::GetConfig;
@@ -32,13 +35,14 @@ namespace ouster_ros {
 // PIMPL implementation class for diagnostics tracker
 class OusterSensor::DiagnosticsImpl {
 public:
-    using TrackerType = SensorDiagnosticsTracker;
+    using RegistryType = DiagnosticsVisitorRegistry<sensor_msgs::msg::PointCloud2, sensor_msgs::msg::Image>;
+    using TrackerType = SensorDiagnosticsTracker<RegistryType>;
 
     std::unique_ptr<TrackerType> tracker;
 
-    DiagnosticsImpl(const std::string& name, OusterSensor* node,
-                   const std::string& hardware_id) {
-        tracker = std::make_unique<TrackerType>(name, node->get_clock(), hardware_id);
+    DiagnosticsImpl(const std::string& name, OusterSensor* node, 
+                   const std::string& hardware_id, const RegistryType& registry) {
+        tracker = std::make_unique<TrackerType>(name, node, hardware_id, registry);
     }
 
     void record_lidar_packet() { tracker->record_lidar_packet(); }
@@ -48,17 +52,21 @@ public:
     void increment_imu_packet_errors() { tracker->increment_imu_packet_errors(); }
     void notify_reset_sensor() { tracker->notify_reset_sensor(); }
     void update_metadata(const ouster::sensor::sensor_info& info) { tracker->update_metadata(info); }
-    void update_status(const std::string& message,
+    void update_status(const std::string& message, 
                       diagnostic_msgs::msg::DiagnosticStatus::_level_type level,
                       const std::map<std::string, std::string>& debug_context) {
         tracker->update_status(message, level, debug_context);
     }
 
-    std::map<std::string, std::string> get_debug_context(const std::string& sensor_hostname,
+    std::map<std::string, std::string> get_debug_context(const std::string& sensor_hostname, 
                                                         bool sensor_connection_active) const {
         return tracker->get_debug_context(sensor_hostname, sensor_connection_active);
     }
 
+    template<typename T>
+    void record_msg(const std::string& topic, const T& msg) {
+        tracker->record_msg(topic, msg);
+    }
 };
 
 OusterSensor::OusterSensor(const std::string& name,
@@ -119,6 +127,8 @@ void OusterSensor::declare_parameters() {
     declare_parameter("use_diagnostics", false);
     declare_parameter("diagnostics.hardware_id", "");
     declare_parameter("diagnostics.name", "");
+    declare_parameter("diagnostics.analyze_pointcloud_msg", false);
+    declare_parameter("diagnostics.analyze_image_msg", false);
 }
 
 bool OusterSensor::start() {
@@ -974,12 +984,46 @@ void OusterSensor::create_diagnostics_pub(const std::string & hardware_id)
 {
   std::string diagnostics_name = get_parameter("diagnostics.name").as_string();
 
+  // Create message analyzer with delay tracking
+  auto analyzer =
+    DiagnosticsVisitorRegistry<sensor_msgs::msg::PointCloud2, sensor_msgs::msg::Image>();
+  auto ros_msg_analyzer =
+    std::make_shared<RosMsgAggregateTimeAnalyzer<sensor_msgs::msg::PointCloud2>>(get_clock());
+  auto ros_msg_image_analyzer =
+    std::make_shared<RosMsgAggregateTimeAnalyzer<sensor_msgs::msg::Image>>(get_clock());
+
+  if (get_parameter("diagnostics.analyze_pointcloud_msg").as_bool()) {
+    analyzer.register_visitor([ros_msg_analyzer](const sensor_msgs::msg::PointCloud2 & msg) {
+      return (*ros_msg_analyzer)(msg);
+    });
+    RCLCPP_INFO(get_logger(), "Point cloud message delay analysis enabled");
+  }
+
+  if (get_parameter("diagnostics.analyze_image_msg").as_bool()) {
+    analyzer.register_visitor([ros_msg_image_analyzer](const sensor_msgs::msg::Image & msg) {
+      return (*ros_msg_image_analyzer)(msg);
+    });
+    RCLCPP_INFO(get_logger(), "Image message delay analysis enabled");
+  }
+
   // Create diagnostics tracker with message analysis capabilities
   diagnostics_tracker = std::make_unique<DiagnosticsImpl>(
-    diagnostics_name, this, hardware_id);
+    diagnostics_name, this, hardware_id, analyzer);
 
   RCLCPP_INFO(get_logger(), "Diagnostics \"%s\" enabled for sensor: %s", diagnostics_name.c_str(), hardware_id.c_str());
 }
+
+template<typename T>
+void OusterSensor::record_diagnostics_msg(const std::string& topic, const T& msg) {
+  if (diagnostics_tracker) {
+    diagnostics_tracker->record_msg(topic, msg);
+  }
+}
+
+// Explicit template instantiations
+template void OusterSensor::record_diagnostics_msg<sensor_msgs::msg::PointCloud2>(const std::string&, const sensor_msgs::msg::PointCloud2&);
+template void OusterSensor::record_diagnostics_msg<sensor_msgs::msg::Image>(const std::string&, const sensor_msgs::msg::Image&);
+
 
 }  // namespace ouster_ros
 

--- a/ouster-ros/src/os_sensor_node.h
+++ b/ouster-ros/src/os_sensor_node.h
@@ -191,6 +191,7 @@ class OusterSensor : public OusterSensorNodeBase {
     double dormant_period_between_reconnects;
     int reconnect_attempts_available;
     rclcpp::TimerBase::SharedPtr reconnect_timer;
+
     std::string diagnostics_hardware_id_;
     std::string diagnostics_name_;
     // PIMPL for diagnostics tracker to hide template specialization

--- a/ouster-ros/src/sensor_diagnostics_tracker.cpp
+++ b/ouster-ros/src/sensor_diagnostics_tracker.cpp
@@ -12,63 +12,69 @@
 namespace ouster_ros
 {
 
-void SensorDiagnosticsTracker::record_lidar_packet()
+void SensorDiagnosticsState::record_lidar_packet()
 {
   last_successful_lidar_frame_ = clock_->now();
   total_lidar_packets_received_++;
 }
 
-void SensorDiagnosticsTracker::record_imu_packet()
+void SensorDiagnosticsState::record_imu_packet()
 {
   last_successful_imu_frame_ = clock_->now();
   total_imu_packets_received_++;
 }
 
-void SensorDiagnosticsTracker::increment_poll_client_errors()
+void SensorDiagnosticsState::increment_poll_client_errors()
 {
   last_client_error_ = clock_->now();
   poll_client_error_count_++;
 }
 
-void SensorDiagnosticsTracker::increment_lidar_packet_errors()
+void SensorDiagnosticsState::increment_lidar_packet_errors()
 {
   last_unsuccessful_lidar_frame_ = clock_->now();
   read_lidar_packet_errors_++;
 }
 
-void SensorDiagnosticsTracker::increment_imu_packet_errors()
+void SensorDiagnosticsState::increment_imu_packet_errors()
 {
   last_unsuccessful_imu_frame_ = clock_->now();
   read_imu_packet_errors_++;
 }
 
-void SensorDiagnosticsTracker::notify_reset_sensor()
+void SensorDiagnosticsState::notify_reset_sensor()
 {
   last_sensor_reset_ = clock_->now();
   total_sensor_resets_++;
 }
 
-rclcpp::Time SensorDiagnosticsTracker::get_zero_time() const
+rclcpp::Time SensorDiagnosticsState::get_zero_time() const
 {
   return rclcpp::Time(0, 0, clock_->get_clock_type());
 }
 
-void SensorDiagnosticsTracker::update_status(
+void SensorDiagnosticsState::update_status(
   const std::string & message, diagnostic_msgs::msg::DiagnosticStatus::_level_type level,
   const std::map<std::string, std::string> & debug_context)
 {
   current_message_ = message;
   current_level_ = level;
   current_debug_context_ = debug_context;
+  message_history_.clear();
 }
 
-diagnostic_msgs::msg::DiagnosticStatus SensorDiagnosticsTracker::get_current_status() const
+diagnostic_msgs::msg::DiagnosticStatus SensorDiagnosticsState::get_current_status() const
 {
   return create_diagnostic_status(current_message_, current_level_, current_debug_context_);
 }
 
+void SensorDiagnosticsState::add_message_analysis(
+  const std::string & topic_name, const std::vector<diagnostic_msgs::msg::KeyValue> & analysis)
+{
+  message_history_[topic_name].push_back(analysis);
+}
 
-std::map<std::string, std::string> SensorDiagnosticsTracker::get_debug_context(
+std::map<std::string, std::string> SensorDiagnosticsState::get_debug_context(
   const std::string & sensor_hostname, bool sensor_connection_active) const
 {
   std::map<std::string, std::string> context;
@@ -96,7 +102,7 @@ std::map<std::string, std::string> SensorDiagnosticsTracker::get_debug_context(
   return context;
 }
 
-diagnostic_msgs::msg::DiagnosticStatus SensorDiagnosticsTracker::create_diagnostic_status(
+diagnostic_msgs::msg::DiagnosticStatus SensorDiagnosticsState::create_diagnostic_status(
   const std::string & message, diagnostic_msgs::msg::DiagnosticStatus::_level_type level,
   const std::map<std::string, std::string> & debug_context) const
 {
@@ -152,10 +158,34 @@ diagnostic_msgs::msg::DiagnosticStatus SensorDiagnosticsTracker::create_diagnost
     add_kv(status.values, context_pair.first, context_pair.second);
   }
 
+  std::vector<diagnostic_msgs::msg::KeyValue> message_history_kv;
+  for (const auto & [topic_name, analyses] : message_history_) {
+    for (const auto & analysis : analyses) {
+      for (const auto & kv : analysis) {
+        add_kv(message_history_kv, topic_name + " " + kv.key, kv.value);
+      }
+    }
+  }
+
+  // Sort and unique keys to avoid duplicates, leave the most recent ones
+  std::stable_sort(
+    message_history_kv.rbegin(), message_history_kv.rend(),
+    [](const diagnostic_msgs::msg::KeyValue & a, const diagnostic_msgs::msg::KeyValue & b) {
+      return a.key < b.key;
+    });
+
+  auto unique_end = std::unique(
+    message_history_kv.rbegin(), message_history_kv.rend(),
+    [](const diagnostic_msgs::msg::KeyValue & a, const diagnostic_msgs::msg::KeyValue & b) {
+      return a.key == b.key;
+    });
+
+  std::move(message_history_kv.rbegin(), unique_end, std::back_inserter(status.values));
+
   return status;
 }
 
-void SensorDiagnosticsTracker::update_metadata(const ouster::sensor::sensor_info & info)
+void SensorDiagnosticsState::update_metadata(const ouster::sensor::sensor_info & info)
 {
   sensor_info_.clear();
 

--- a/ouster-ros/test/test_msg_analyzers.cpp
+++ b/ouster-ros/test/test_msg_analyzers.cpp
@@ -72,6 +72,7 @@ TEST_F(MsgAnalyzersTest, RosMsgAggregateTimeAnalyzer) {
     for(int i = 0; i < 10; ++i) {
         sensor_msgs::msg::PointCloud2 msg;
         msg.header.stamp = now + rclcpp::Duration::from_seconds(i * 100);
+        msgs.push_back(msg);
     }
 
     std::vector<diagnostic_msgs::msg::KeyValue> last_results;
@@ -88,7 +89,7 @@ TEST_F(MsgAnalyzersTest, AggregateFunction) {
     for(int i = 0; i < 5; ++i) {
         detail::MsgTimeInfo info;
         info.msg_timestamp = now + rclcpp::Duration::from_nanoseconds(i * 100000);
-        info.received_msg = now + rclcpp::Duration::from_nanoseconds((i * 100 + 10) * 100000);
+         info.received_msg = now + rclcpp::Duration::from_nanoseconds(i * 100000 + 10000);
         buffer.push_back(info);
     }
 

--- a/ouster-ros/test/test_msg_analyzers.cpp
+++ b/ouster-ros/test/test_msg_analyzers.cpp
@@ -20,15 +20,21 @@ namespace test {
 
 class MsgAnalyzersTest : public ::testing::Test {
   protected:
-    void SetUp() override {
+    static void SetUpTestSuite() {
         rclcpp::init(0, nullptr);
+    }
+
+    static void TearDownTestSuite() {
+        rclcpp::shutdown();
+    }
+
+    void SetUp() override {
         node_ = std::make_shared<rclcpp::Node>("test_msg_analyzers");
         clock_ = node_->get_clock();
     }
 
     void TearDown() override {
         node_.reset();
-        rclcpp::shutdown();
     }
 
     rclcpp::Node::SharedPtr node_;

--- a/ouster-ros/test/test_msg_analyzers.cpp
+++ b/ouster-ros/test/test_msg_analyzers.cpp
@@ -1,0 +1,136 @@
+/**
+ * Copyright (c) 2018-2025, Ouster, Inc.
+ * All rights reserved.
+ *
+ * @file test_msg_analyzers.cpp
+ * @brief Tests for message analysis utilities for Ouster sensors
+ */
+
+
+#include <gtest/gtest.h>
+#include <rclcpp/rclcpp.hpp>
+#include <sensor_msgs/msg/point_cloud2.hpp>
+#include <sensor_msgs/msg/image.hpp>
+#include <diagnostic_msgs/msg/key_value.hpp>
+
+#include "../src/msg_analyzers.h"
+
+namespace ouster_ros {
+namespace test {
+
+class MsgAnalyzersTest : public ::testing::Test {
+  protected:
+    void SetUp() override {
+        rclcpp::init(0, nullptr);
+        node_ = std::make_shared<rclcpp::Node>("test_msg_analyzers");
+        clock_ = node_->get_clock();
+    }
+
+    void TearDown() override {
+        node_.reset();
+        rclcpp::shutdown();
+    }
+
+    rclcpp::Node::SharedPtr node_;
+    rclcpp::Clock::SharedPtr clock_;
+};
+
+TEST_F(MsgAnalyzersTest, PointCloudMsgAnalysis) {
+    sensor_msgs::msg::PointCloud2 pc_msg;
+    pc_msg.header.stamp = clock_->now();
+    pc_msg.header.frame_id = "os_sensor";
+    pc_msg.height = 64;
+    pc_msg.width = 1024;
+
+    auto results = analyze_msg(pc_msg);
+
+
+    EXPECT_FALSE(results.empty());
+}
+
+TEST_F(MsgAnalyzersTest, ImageMsgAnalysis) {
+    sensor_msgs::msg::Image img_msg;
+    img_msg.header.stamp = clock_->now();
+    img_msg.header.frame_id = "os_sensor";
+
+    auto results = analyze_msg(img_msg);
+    EXPECT_FALSE(results.empty());
+}
+
+TEST_F(MsgAnalyzersTest, RosMsgAggregateTimeAnalyzer) {
+    RosMsgAggregateTimeAnalyzer<sensor_msgs::msg::PointCloud2> analyzer(clock_);
+
+    std::vector<sensor_msgs::msg::PointCloud2> msgs;
+    auto now = clock_->now();
+
+    for(int i = 0; i < 10; ++i) {
+        sensor_msgs::msg::PointCloud2 msg;
+        msg.header.stamp = now + rclcpp::Duration::from_seconds(i * 100);
+    }
+
+    std::vector<diagnostic_msgs::msg::KeyValue> last_results;
+    for(const auto& msg : msgs) {
+        last_results = analyzer(msg);
+        EXPECT_FALSE(last_results.empty());
+    }
+}
+
+TEST_F(MsgAnalyzersTest, AggregateFunction) {
+    RingBuffer<detail::MsgTimeInfo> buffer;
+    auto now = clock_->now();
+
+    for(int i = 0; i < 5; ++i) {
+        detail::MsgTimeInfo info;
+        info.msg_timestamp = now + rclcpp::Duration::from_nanoseconds(i * 100000);
+        info.received_msg = now + rclcpp::Duration::from_nanoseconds((i * 100 + 10) * 100000);
+        buffer.push_back(info);
+    }
+
+    auto results = detail::aggregate(buffer);
+
+    EXPECT_FALSE(results.empty());
+}
+
+TEST_F(MsgAnalyzersTest, AggregateResultValues) {
+    RingBuffer<detail::MsgTimeInfo> buffer;
+    auto now = clock_->now();
+
+    // Add entries with known time differences
+    for(int i = 0; i < 5; ++i) {
+        detail::MsgTimeInfo info;
+        info.msg_timestamp = now;
+        info.received_msg =
+            now + rclcpp::Duration::from_seconds(i + 1); // 1s, 2s, 3s, 4s, 5s differences
+        buffer.push_back(info);
+    }
+
+    auto results = detail::aggregate(buffer);
+
+    // Find the time_diff_min key-value
+    auto min_it = std::find_if(results.begin(), results.end(),
+                               [](const auto& kv) { return kv.key == "time_diff_min"; });
+    ASSERT_NE(min_it, results.end()) << "time_diff_min not found in results";
+    EXPECT_NEAR(std::stod(min_it->value), 1.0, 0.01) << "Min time diff should be 1.0s";
+
+    // Find the time_diff_max key-value
+    auto max_it = std::find_if(results.begin(), results.end(),
+                               [](const auto& kv) { return kv.key == "time_diff_max"; });
+    ASSERT_NE(max_it, results.end()) << "time_diff_max not found in results";
+    EXPECT_NEAR(std::stod(max_it->value), 5.0, 0.01) << "Max time diff should be 5.0s";
+
+    // Find the time_diff_avg key-value
+    auto avg_it = std::find_if(results.begin(), results.end(),
+                               [](const auto& kv) { return kv.key == "time_diff_avg"; });
+    ASSERT_NE(avg_it, results.end()) << "time_diff_avg not found in results";
+    EXPECT_NEAR(std::stod(avg_it->value), 3.0, 0.01) << "Average time diff should be 3.0s";
+
+    // Check number of frames
+    auto frames_it = std::find_if(results.begin(), results.end(),
+                                  [](const auto& kv) { return kv.key == "time_diff_frames"; });
+    ASSERT_NE(frames_it, results.end()) << "time_diff_frames not found in results";
+    EXPECT_EQ(std::stoi(frames_it->value), 5) << "Frame count should be 5";
+}
+
+
+} // namespace test
+} // namespace ouster_ros

--- a/ouster-ros/test/test_sensor_diagnostics_tracker.cpp
+++ b/ouster-ros/test/test_sensor_diagnostics_tracker.cpp
@@ -13,6 +13,7 @@
 #include <std_msgs/msg/string.hpp>
 #include <string>
 
+#include "ouster_ros/diagnostics_visitor_registry.h"
 #include "ouster_ros/sensor_diagnostics_tracker.h"
 
 namespace ouster_ros
@@ -26,13 +27,15 @@ protected:
   void SetUp() override
   {
     clock_ = std::make_shared<rclcpp::Clock>(RCL_STEADY_TIME);
-    tracker_ = std::make_unique<ouster_ros::SensorDiagnosticsTracker>(
+    tracker_ = std::make_unique<ouster_ros::SensorDiagnosticsTracker<
+      DiagnosticsVisitorRegistry<sensor_msgs::msg::PointCloud2, sensor_msgs::msg::Image>>>(
       "test_sensor", clock_, "test_hardware_id");
   }
 
   rclcpp::Clock::SharedPtr clock_;
-  std::unique_ptr<ouster_ros::SensorDiagnosticsTracker> tracker_;
-
+  std::unique_ptr<ouster_ros::SensorDiagnosticsTracker<
+    DiagnosticsVisitorRegistry<sensor_msgs::msg::PointCloud2, sensor_msgs::msg::Image>>>
+    tracker_;
 };
 
 TEST_F(SensorDiagnosticsTrackerTest, InitialState)
@@ -153,6 +156,66 @@ TEST_F(SensorDiagnosticsTrackerTest, CreateDiagnosticStatus)
   EXPECT_TRUE(found_key2);
 }
 
+TEST_F(SensorDiagnosticsTrackerTest, RecordMsgWithAnalyzer)
+{
+  auto analyzer = DiagnosticsVisitorRegistry<sensor_msgs::msg::PointCloud2>(
+    [](const sensor_msgs::msg::PointCloud2 & msg) -> std::vector<diagnostic_msgs::msg::KeyValue> {
+      diagnostic_msgs::msg::KeyValue kv;
+      kv.key = "height";
+      kv.value = std::to_string(msg.height);
+      return {kv};
+    });
+
+  auto tracker = SensorDiagnosticsTracker("test_sensor", clock_, "test_hardware_id", analyzer);
+
+  sensor_msgs::msg::PointCloud2 cloud_msg;
+  cloud_msg.height = 10;
+
+  tracker.record_msg("point_cloud", cloud_msg);
+  auto status = tracker.get_current_status();
+  EXPECT_EQ(find_key_value(status.values, "point_cloud height"), std::to_string(cloud_msg.height));
+}
+
+TEST_F(SensorDiagnosticsTrackerTest, RecordMultipleMessagesWithAnalyzer)
+{
+  auto analyzer =
+    DiagnosticsVisitorRegistry<sensor_msgs::msg::PointCloud2, sensor_msgs::msg::Image>(
+      [](const sensor_msgs::msg::PointCloud2 & msg) -> std::vector<diagnostic_msgs::msg::KeyValue> {
+        diagnostic_msgs::msg::KeyValue kv;
+        kv.key = "size";
+        kv.value = std::to_string(msg.height * msg.width);
+        return {kv};
+      },
+      [](const sensor_msgs::msg::Image & msg) -> std::vector<diagnostic_msgs::msg::KeyValue> {
+        diagnostic_msgs::msg::KeyValue kv;
+        kv.key = "size";
+        kv.value = std::to_string(msg.height * msg.width);
+        return {kv};
+      });
+
+  auto tracker = SensorDiagnosticsTracker("test_sensor", clock_, "test_hardware_id", analyzer);
+
+  sensor_msgs::msg::PointCloud2 cloud_msg;
+  cloud_msg.height = 10;
+  cloud_msg.width = 20;
+
+  sensor_msgs::msg::Image image_msg;
+  image_msg.height = 30;
+  image_msg.width = 40;
+
+  tracker.record_msg("point_cloud", cloud_msg);
+  tracker.record_msg("image", image_msg);
+
+  auto status = tracker.get_current_status();
+  EXPECT_EQ(
+    find_key_value(status.values, "point_cloud size"),
+    std::to_string(cloud_msg.height * cloud_msg.width));
+
+  EXPECT_EQ(
+    find_key_value(status.values, "image size"),
+    std::to_string(image_msg.height * image_msg.width));
+}
+
 TEST_F(SensorDiagnosticsTrackerTest, UpdateMetadata)
 {
   ouster::sensor::sensor_info info;
@@ -181,6 +244,200 @@ TEST_F(SensorDiagnosticsTrackerTest, UpdateMetadata)
   }
   EXPECT_TRUE(found_serial);
   EXPECT_TRUE(found_firmware);
+}
+
+TEST_F(SensorDiagnosticsTrackerTest, VisitorRegistration)
+{
+  auto registry =
+    DiagnosticsVisitorRegistry<sensor_msgs::msg::PointCloud2, sensor_msgs::msg::Image>();
+
+  registry.register_visitor(
+    [](const sensor_msgs::msg::PointCloud2 & msg) -> std::vector<diagnostic_msgs::msg::KeyValue> {
+      diagnostic_msgs::msg::KeyValue kv;
+      kv.key = "explicit_registration";
+      kv.value = std::to_string(msg.height);
+      return {kv};
+    });
+
+  EXPECT_TRUE(registry.has_visitor<sensor_msgs::msg::PointCloud2>());
+  EXPECT_FALSE(registry.has_visitor<sensor_msgs::msg::Image>());
+
+  sensor_msgs::msg::PointCloud2 cloud_msg;
+  cloud_msg.height = 42;
+
+  auto result = registry(cloud_msg);
+  ASSERT_EQ(result.size(), 1);
+  EXPECT_EQ(result[0].key, "explicit_registration");
+  EXPECT_EQ(result[0].value, "42");
+}
+
+TEST_F(SensorDiagnosticsTrackerTest, VisitorOverwrite)
+{
+  auto registry = DiagnosticsVisitorRegistry<sensor_msgs::msg::PointCloud2>();
+
+  registry.register_visitor(
+    [](const sensor_msgs::msg::PointCloud2 & msg) -> std::vector<diagnostic_msgs::msg::KeyValue> {
+      (void)msg;
+      diagnostic_msgs::msg::KeyValue kv;
+      kv.key = "first_visitor";
+      kv.value = "first";
+      return {kv};
+    });
+
+  registry.register_visitor(
+    [](const sensor_msgs::msg::PointCloud2 & msg) -> std::vector<diagnostic_msgs::msg::KeyValue> {
+      (void)msg;
+      diagnostic_msgs::msg::KeyValue kv;
+      kv.key = "second_visitor";
+      kv.value = "second";
+      return {kv};
+    });
+
+  sensor_msgs::msg::PointCloud2 cloud_msg;
+  auto result = registry(cloud_msg);
+  ASSERT_EQ(result.size(), 1);
+  EXPECT_EQ(result[0].key, "second_visitor");
+  EXPECT_EQ(result[0].value, "second");
+}
+
+TEST_F(SensorDiagnosticsTrackerTest, VisitorMixedRegistration)
+{
+  auto registry =
+    DiagnosticsVisitorRegistry<sensor_msgs::msg::PointCloud2, sensor_msgs::msg::Image>(
+      [](const sensor_msgs::msg::PointCloud2 & msg) -> std::vector<diagnostic_msgs::msg::KeyValue> {
+        (void)msg;
+        diagnostic_msgs::msg::KeyValue kv;
+        kv.key = "constructor_visitor";
+        kv.value = "constructor";
+        return {kv};
+      });
+  registry.register_visitor(
+    [](const sensor_msgs::msg::Image & msg) -> std::vector<diagnostic_msgs::msg::KeyValue> {
+      (void)msg;
+      diagnostic_msgs::msg::KeyValue kv;
+      kv.key = "public_visitor";
+      kv.value = "public";
+      return {kv};
+    });
+
+  EXPECT_TRUE(registry.has_visitor<sensor_msgs::msg::PointCloud2>());
+  EXPECT_TRUE(registry.has_visitor<sensor_msgs::msg::Image>());
+
+  sensor_msgs::msg::PointCloud2 cloud_msg;
+  auto cloud_result = registry(cloud_msg);
+  ASSERT_EQ(cloud_result.size(), 1);
+  EXPECT_EQ(cloud_result[0].key, "constructor_visitor");
+
+  sensor_msgs::msg::Image image_msg;
+  auto image_result = registry(image_msg);
+  ASSERT_EQ(image_result.size(), 1);
+  EXPECT_EQ(image_result[0].key, "public_visitor");
+}
+
+TEST_F(SensorDiagnosticsTrackerTest, VisitorMixedRegistrationFunc)
+{
+  DiagnosticsVisitorRegistry<sensor_msgs::msg::PointCloud2, sensor_msgs::msg::Image> registry;
+
+  registry.register_visitor(
+    [](const sensor_msgs::msg::PointCloud2 & msg) -> std::vector<diagnostic_msgs::msg::KeyValue> {
+      (void)msg;
+      diagnostic_msgs::msg::KeyValue kv;
+      kv.key = "constructor_visitor";
+      kv.value = "constructor";
+      return {kv};
+    });
+
+  registry.register_visitor(
+    [](const sensor_msgs::msg::Image & msg) -> std::vector<diagnostic_msgs::msg::KeyValue> {
+      (void)msg;
+      diagnostic_msgs::msg::KeyValue kv;
+      kv.key = "public_visitor";
+      kv.value = "public";
+      return {kv};
+    });
+
+  // Test both visitors work
+  EXPECT_TRUE(registry.has_visitor<sensor_msgs::msg::PointCloud2>());
+  EXPECT_TRUE(registry.has_visitor<sensor_msgs::msg::Image>());
+
+  sensor_msgs::msg::PointCloud2 cloud_msg;
+  auto cloud_result = registry(cloud_msg);
+  ASSERT_EQ(cloud_result.size(), 1);
+  EXPECT_EQ(cloud_result[0].key, "constructor_visitor");
+
+  sensor_msgs::msg::Image image_msg;
+  auto image_result = registry(image_msg);
+  ASSERT_EQ(image_result.size(), 1);
+  EXPECT_EQ(image_result[0].key, "public_visitor");
+}
+
+TEST_F(SensorDiagnosticsTrackerTest, TestMessageHistorySorting)
+{
+  auto registry = DiagnosticsVisitorRegistry<sensor_msgs::msg::PointCloud2>();
+  registry.register_visitor(
+    [](const sensor_msgs::msg::PointCloud2 & msg) -> std::vector<diagnostic_msgs::msg::KeyValue> {
+      diagnostic_msgs::msg::KeyValue kv;
+      kv.key = "height";
+      kv.value = std::to_string(msg.height);
+      return {kv};
+    });
+  auto tracker = SensorDiagnosticsTracker("test_sensor", clock_, "test_hardware_id", registry);
+
+  sensor_msgs::msg::PointCloud2 msg;
+  msg.height = 10;
+  msg.width = 20;
+
+  tracker.record_msg("topic1 height", msg);
+  tracker.record_msg("topic2 height", msg);
+  tracker.record_msg("topic3 height", msg);
+
+  auto status = tracker.get_current_status();
+
+  bool found_topic1 = false, found_topic2 = false, found_topic3 = false;
+  for (const auto & kv : status.values) {
+    if (kv.key.find("topic1") != std::string::npos) found_topic1 = true;
+    if (kv.key.find("topic2") != std::string::npos) found_topic2 = true;
+    if (kv.key.find("topic3") != std::string::npos) found_topic3 = true;
+  }
+
+  EXPECT_TRUE(found_topic1);
+  EXPECT_TRUE(found_topic2);
+  EXPECT_TRUE(found_topic3);
+}
+
+TEST_F(SensorDiagnosticsTrackerTest, TestMessageHistoryUniqueness)
+{
+  auto registry = DiagnosticsVisitorRegistry<sensor_msgs::msg::PointCloud2>();
+  registry.register_visitor(
+    [](const sensor_msgs::msg::PointCloud2 & msg) -> std::vector<diagnostic_msgs::msg::KeyValue> {
+      diagnostic_msgs::msg::KeyValue kv;
+      kv.key = "duplicate_key";
+      kv.value = std::to_string(msg.height);
+      return {kv};
+    });
+
+  auto tracker = SensorDiagnosticsTracker("test_sensor", clock_, "test_hardware_id", registry);
+
+  sensor_msgs::msg::PointCloud2 msg;
+  msg.height = 10;
+  tracker.record_msg("topic_name", msg);
+
+  msg.height = 20;
+  tracker.record_msg("topic_name", msg);
+
+  auto status = tracker.get_current_status();
+
+  int count = 0;
+  std::string last_value;
+  for (const auto & kv : status.values) {
+    if (kv.key == "topic_name duplicate_key") {
+      count++;
+      last_value = kv.value;
+    }
+  }
+
+  EXPECT_EQ(count, 1);
+  EXPECT_EQ(last_value, "20");
 }
 
 TEST_F(SensorDiagnosticsTrackerTest, TestDiagnosticStatusFormat)


### PR DESCRIPTION
## Summary of Changes

This PR adds 
This pull request introduces significant improvements to the Ouster ROS package, focusing on diagnostics infrastructure, architectural documentation, and build system updates. The most important changes include the addition of a flexible diagnostics visitor registry, enhancements to the sensor node base for diagnostics publishing, a new ring buffer utility, expanded build dependencies, and a comprehensive class diagram for architectural clarity.

### Diagnostics Infrastructure

* Added a generic `DiagnosticsVisitorRegistry` template class in `diagnostics_visitor_registry.h`, enabling flexible registration and execution of message-specific diagnostics analyzers without Ouster SDK dependencies.
* Enhanced `OusterSensorNodeBase` with diagnostics publishing capabilities, including new methods for creating, publishing, and updating diagnostics, and integration of a diagnostics tracker with visitor registry support. [[1]](diffhunk://#diff-dc133ca34a17dfcc79f2ef415697b31df352c60f63109a5f9853e59429225fa1R47-R54) [[2]](diffhunk://#diff-dc133ca34a17dfcc79f2ef415697b31df352c60f63109a5f9853e59429225fa1R80-R86)

### Utilities

* Introduced a new `RingBuffer` utility class in `ring_buffer.h` for efficient, capacity-limited storage, supporting both value and move semantics, iterator access, and dynamic capacity adjustment.

### Build System and Dependencies

* Updated `CMakeLists.txt` to include `diagnostic_msgs` as a required dependency, added relevant source files for diagnostics to component builds, and expanded test coverage to include diagnostics-related files and tests. [[1]](diffhunk://#diff-3ac9eb363139b32e5c4f799661b631a4ee9510f5d1415737c1163c4e4640372eR25) [[2]](diffhunk://#diff-3ac9eb363139b32e5c4f799661b631a4ee9510f5d1415737c1163c4e4640372eR81) [[3]](diffhunk://#diff-3ac9eb363139b32e5c4f799661b631a4ee9510f5d1415737c1163c4e4640372eR119) [[4]](diffhunk://#diff-3ac9eb363139b32e5c4f799661b631a4ee9510f5d1415737c1163c4e4640372eL130-R133) [[5]](diffhunk://#diff-3ac9eb363139b32e5c4f799661b631a4ee9510f5d1415737c1163c4e4640372eL170-R173) [[6]](diffhunk://#diff-3ac9eb363139b32e5c4f799661b631a4ee9510f5d1415737c1163c4e4640372eR199-R207)

### Documentation

* Added a detailed class diagram in `docs/class-diagram.md` using Mermaid syntax, illustrating inheritance, aggregation, and key architectural patterns of the Ouster ROS nodes and utilities.

### Code Hygiene

* Added missing `#pragma once` directives to several header files to prevent multiple inclusion and improve compilation reliability. [[1]](diffhunk://#diff-4159a50b4b3f9b860ab69464695d8adf740e5b2474fbe92887ba1cb2d4ab48eeR9) [[2]](diffhunk://#diff-dc133ca34a17dfcc79f2ef415697b31df352c60f63109a5f9853e59429225fa1R9-R25)


## Validation

```
ros2 topic echo /diagnostics

---
header:
  stamp:
    sec: 1757575384
    nanosec: 672687729
  frame_id: ''
status:
- level: "\0"
  name: 'ouster_os16_roof: /sensors/lidar/ouster_os16_roof Status'
  message: Sensor operating normally
  hardware_id: 192.168.11.19
  values:
  - key: Last Update
    value: '1757575384.672565'
  - key: Last Sensor Reset
    value: '0.000000'
  - key: Total Sensor Resets
    value: '0'
  - key: Sensor Uptime (s)
    value: '7.003988'
  - key: Last successful LiDAR frame
    value: '1757575384.672535'
  - key: Last unsuccessful LiDAR frame
    value: '0.000000'
  - key: Total LIDAR Packets
    value: '8797'
  - key: LIDAR Packet Errors
    value: '0'
  - key: Last successful IMU frame
    value: '1757575384.670379'
  - key: Last unsuccessful IMU frame
    value: '0.000000'
  - key: Total IMU Packets
    value: '694'
  - key: IMU Packet Errors
    value: '0'
  - key: Poll Client Errors
    value: '0'
  - key: Last Client Error
    value: '0.000000'
  - key: Sensor Firmware Version
    value: v2.3.1
  - key: Sensor Info JSON Length
    value: '3782'
  - key: Sensor Serial Number
    value: '992004000513'
  - key: Sensor beam_altitude_angles
    value: '16'
  - key: Sensor beam_azimuth_angles
    value: '16'
  - key: Sensor columns_per_frame
    value: '1024'
  - key: Sensor columns_per_packet
    value: '16'
  - key: Sensor fw_ver
    value: v2.3.1
  - key: Sensor lidar_mode
    value: 1024x20
  - key: Sensor pixels_per_column
    value: '16'
  - key: Sensor prod_line
    value: OS-1-16-A2
  - key: Sensor prod_pn
    value: 840-101855-02
  - key: Sensor Connection Active
    value: 'false'
  - key: Sensor Hostname
    value: unknown
  - key: Time Since Last IMU Frame (ms)
    value: '2'
  - key: Time Since Last LiDAR Frame (ms)
    value: '0'
  - key: /sensors/lidar/ouster_os16_roof/points time_diff_avg
    value: '0.062346'
  - key: /sensors/lidar/ouster_os16_roof/points time_diff_frames
    value: '100'
  - key: /sensors/lidar/ouster_os16_roof/points time_diff_max
    value: '0.064366'
  - key: /sensors/lidar/ouster_os16_roof/points time_diff_min
    value: '0.060724'
```
